### PR TITLE
InfluxDB v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ python3 listen.py --influxdb --influxdb_host=influxdb --influxdb_port=8086  --in
 
 ```
 
-For InfluxDB API Version 2 (including v1.8 with v2 compatibility API), a different python library is used, *so different parameters are required.*  API version 2 requires token-based authentication.
+For InfluxDB API Version 2 (including v1.8 with v2 compatibility API), a [different python library](https://github.com/influxdata/influxdb-client-python) is used, *so different parameters are required.*  API version 2 requires token-based authentication.
 
 ```
 python3 listen.py --influxdb2 --influxdb2_url "http://influxdb:8086/" --influxdb2_org testorg --influxdb2_bucket testbucket --influxdb2_token "SOMETOKEN" -M -n

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ This requires installing the paho mqtt and influxdb python libraries.
 On a debian(ish) system that can be done by:
 ```
 # for python3
-sudo apt-get install -y python3-pip && sudo pip3 install paho-mqtt influxdb
+sudo apt-get install -y python3-pip && sudo pip3 install paho-mqtt influxdb influxdb-client
 
 # for python2
-sudo apt-get install -y python-pip  && sudo pip  install paho-mqtt influxdb
+sudo apt-get install -y python-pip  && sudo pip  install paho-mqtt influxdb influxdb-client
 ```
 
 ##  Usage


### PR DESCRIPTION
Added InfluxDB v2 support separate from v1.x.

The client library and semantics are a bit different from v1 to v2, so to avoid confusion there, a new set of command line parameters and a new `publish` method were added.

In theory you can even push to v1 and v2 simultaneously.